### PR TITLE
fixed unix timestamp issue on windows

### DIFF
--- a/firebasin/dataref.py
+++ b/firebasin/dataref.py
@@ -2,6 +2,7 @@ import atexit
 import math
 import random
 import time
+import datetime
 
 from connection import Connection
 from structure import Structure
@@ -201,8 +202,13 @@ class DataRef(object):
     def _get_push_id(self):
         ''' Return a new string containing an ID for pushing. '''
 
-        now = time.time()
-        timestamp = int(now * 1000)
+        now = datetime.datetime.now()
+
+        try:
+            timestamp = int(now.strftime('%s%f')[:-3])
+        except ValueError:
+            now = time.time()
+            timestamp = int(now * 1000)
 
         characters = "-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz"
 


### PR DESCRIPTION
Generating unix timestamp using <em>time.time()</em> for greater portability. Also moved local variable <em>path_data</em> inside the else clause so as to avoid being referenced before assignment
