### PR TITLE
Fixed incorrect slice in DataRef's name() function.

### DIFF
--- a/firebasin/dataref.py
+++ b/firebasin/dataref.py
@@ -76,7 +76,7 @@ class DataRef(object):
     def name(self):
         '''Get the last node (name) of this Firebase location.'''
 
-        last_node = [p for p in self.path.split('/') if p][:-1]
+        last_node = [p for p in self.path.split('/') if p][-1:]
         if last_node:
             return last_node
         else:


### PR DESCRIPTION
The slice was misplaced as [:-1] instead of [-1:], causing it to return a list of tokens for all nodes EXCEPT the last one.
