### PR TITLE
Allow ssl_options to be provided

### DIFF
--- a/firebasin/dataref.py
+++ b/firebasin/dataref.py
@@ -244,9 +244,9 @@ class DataRef(object):
 class RootDataRef(DataRef):
     '''A reference to a root of a Firbase.'''
 
-    def __init__(self, url):
+    def __init__(self, url, ssl_options=None):
         '''Construct a new Firebase reference from a full Firebase URL.'''
-        self.connection = Connection(url, self)
+        self.connection = Connection(url, self, ssl_options=ssl_options)
         self.base_url = url
         self.structure = Structure(self)
         self.subscriptions = {}

--- a/firebasin/firebase.py
+++ b/firebasin/firebase.py
@@ -1,11 +1,11 @@
 from dataref import RootDataRef
 import urlparse
 
-def Firebase(firebaseUrl):
+def Firebase(firebaseUrl, ssl_options=None):
     '''Construct a new Firebase reference from a full Firebase URL.'''
 
     url = urlparse.urlparse(firebaseUrl)
-    root = RootDataRef('https://' + url.netloc)
+    root = RootDataRef('https://' + url.netloc, ssl_options=ssl_options)
     if url.path == '/' or url.path == '': 
         return root 
     else:


### PR DESCRIPTION
Allows ssl_options to be provided when creating a Firebase instance.

Provides the ability to do things like force the client to use TLS (which is what I needed):

```
import ssl
firebase = Firebase('http://..', ssl_options={'ssl_version': ssl.PROTOCOL_TLSv1})
```
